### PR TITLE
Prevent deadlock when Windows Forms are loaded in the PowerShell process

### DIFF
--- a/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
+++ b/src/Microsoft.PowerShell.Commands.Utility/commands/utility/WebCmdlet/StreamHelper.cs
@@ -338,7 +338,7 @@ namespace Microsoft.PowerShell.Commands
         {
             if (perReadTimeout == Timeout.InfiniteTimeSpan)
             {
-                return await reader.ReadToEndAsync(cancellationToken);
+                return await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
             }
 
             int useBufferSize = 4096;
@@ -348,7 +348,7 @@ namespace Microsoft.PowerShell.Commands
                 Memory<char> buffer = chars.AsMemory();
                 StringBuilder sb = new StringBuilder(useBufferSize);
                 int charsRead = 0;
-                while ((charsRead = await reader.ReadAsync(buffer, perReadTimeout, cancellationToken)) != 0)
+                while ((charsRead = await reader.ReadAsync(buffer, perReadTimeout, cancellationToken).ConfigureAwait(false)) != 0)
                 {
                     sb.Append(chars, 0, charsRead);
                 }
@@ -537,7 +537,7 @@ namespace Microsoft.PowerShell.Commands
             int bufferLength = (int)Math.Min(reader.BaseStream.Length, 1024);
 
             char[] buffer = new char[bufferLength];
-            await reader.ReadBlockAsync(buffer.AsMemory(), perReadTimeout, cancellationToken);
+            await reader.ReadBlockAsync(buffer.AsMemory(), perReadTimeout, cancellationToken).ConfigureAwait(false);
             stream.Seek(0, SeekOrigin.Begin);
 
             // Only try to parse meta element and XML declaration if getting encoding from charset


### PR DESCRIPTION

# PR Summary

Must use ConfigureAwait(false) on any awaited methods to prevent use of windows forms in the PowerShell process
from deadlocking the process. This was the cause of the CI failure - test was added specifically for this issue that causes the CI test to deadlock and time out the build stage.
